### PR TITLE
Updates from UNH testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ Thumbs.db
 ###########################
 build/*
 .vscode/*
+kmall.egg-info
 
 # Backup files #
 ################

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ build/*
 #########################
 *.ipynb_checkpoints/*
 
+# Distribution / packaging
+##########################
+*.egg-info/
+

--- a/KMALL/kmall.py
+++ b/KMALL/kmall.py
@@ -1045,7 +1045,11 @@ class kmall():
         # TODO: Test with water column data, phaseFlag = 1 and phaseFlag = 2 to ensure this continues to function properly.
 
         dg = {}
-        format_to_unpack = "1f4H"
+
+        # The "detectedRangeInSamplesHighResolution" field is present in my dgmVersion==2
+        # and ==3 data, but given it wasn't implemented in the upstream library, wonder if
+        # it wasn't present in dgmVersion==1
+        format_to_unpack = "1f4H1f"
         fields = struct.unpack(format_to_unpack, self.FID.read(struct.Struct(format_to_unpack).size))
 
         dg['beamPointAngReVertical_deg'] = fields[0]
@@ -1057,6 +1061,9 @@ class kmall():
         dg['beamTxSectorNum'] = fields[3]
         # Number of sample data for current beam. Also denoted Ns.
         dg['numSampleData'] = fields[4]
+
+        # Two way range as a higher resolution floating point value
+        dg['detectedRangeInSamplesHighResolution'] = fields[5]
 
         # Pointer to start of array with Water Column data. Length of array = numSampleData.
         # Sample amplitudes in 0.5 dB resolution. Size of array is numSampleData * int8_t.

--- a/KMALL/kmall.py
+++ b/KMALL/kmall.py
@@ -1047,7 +1047,7 @@ class kmall():
         dg = {}
 
         # The "detectedRangeInSamplesHighResolution" field is present in my dgmVersion==2
-        # and ==3 data.  Given it wasn't implemented in the upstream library, wonder if
+        # data.  Given it wasn't implemented in the upstream library, wonder if
         # it wasn't present in dgmVersion==1?
         format_to_unpack = "1f4H1f"
         fields = struct.unpack(format_to_unpack, self.FID.read(struct.Struct(format_to_unpack).size))

--- a/KMALL/kmall.py
+++ b/KMALL/kmall.py
@@ -1047,8 +1047,8 @@ class kmall():
         dg = {}
 
         # The "detectedRangeInSamplesHighResolution" field is present in my dgmVersion==2
-        # and ==3 data, but given it wasn't implemented in the upstream library, wonder if
-        # it wasn't present in dgmVersion==1
+        # and ==3 data.  Given it wasn't implemented in the upstream library, wonder if
+        # it wasn't present in dgmVersion==1?
         format_to_unpack = "1f4H1f"
         fields = struct.unpack(format_to_unpack, self.FID.read(struct.Struct(format_to_unpack).size))
 
@@ -1062,7 +1062,11 @@ class kmall():
         # Number of sample data for current beam. Also denoted Ns.
         dg['numSampleData'] = fields[4]
 
-        # Two way range as a higher resolution floating point value
+        # The same information as in detectedRangeInSamples with higher
+        # resolution. Two way range in samples. Approximation to calculated
+        # distance from tx to bottom detection
+        # [meters] = soundVelocity_mPerSec * detectedRangeInSamples / (sampleFreq_Hz * 2)
+        # The detected range is set to zero when the beam has no bottom detection.
         dg['detectedRangeInSamplesHighResolution'] = fields[5]
 
         # Pointer to start of array with Water Column data. Length of array = numSampleData.

--- a/KMALL/kmall.py
+++ b/KMALL/kmall.py
@@ -182,6 +182,26 @@ class kmall():
             print('Unable to find {} in file'.format(datagram_identifier))
         return self.datagram_data
 
+
+    # Datagram should be a row from the Index
+    def read_index_row( self, datagram, header_only=False, rewind=False ):
+        if self.FID is None:
+            self.OpenFiletoRead()
+
+        current_pos = self.FID.tell()
+
+        self.FID.seek(datagram.ByteOffset,0)
+
+        self.decode_datagram()
+
+        if not header_only:
+            self.read_datagram()
+
+        if rewind:
+            self.FID.seek(current_pos,0)
+
+        return self.datagram_data
+
     ###########################################################
     # Reading datagrams
     ###########################################################

--- a/KMALL/kmall.py
+++ b/KMALL/kmall.py
@@ -3459,7 +3459,7 @@ class kmall():
             return d_of_l
             
         else:
-            return None
+            return {}
     
 
     def extractLonLatZ(self):
@@ -4148,7 +4148,7 @@ class kmall():
                         'Yaw Stabilisation Heading Filter')
                     translatedvalues.insert(
                         translatedkeys.index('Yaw Stabilisation Mode')+1,
-                        None)
+                        '')
             translated = dict(zip(translatedkeys,translatedvalues))
 
 

--- a/KMALL/kmall.py
+++ b/KMALL/kmall.py
@@ -4194,6 +4194,7 @@ class kmall():
                             'ISY=': '_starboard_sector_starboard', 'ISZ=': '_starboard_sector_down',
                             'ITX=': '_tx_forward', 'ITY=': '_tx_starboard', 'ITZ=': '_tx_down',
                             'IRX=': '_rx_forward', 'IRY=': '_rx_starboard', 'IRZ=': '_rx_down', 'D=': '_time_delay',
+                            'IX=': '_unknown_forward', 'IY=': '_unknown_starboard', 'IZ=': '_unknown_down',
                             'G=': '_datum', 'T=': '_time_stamp', 'C=': '_motion_compensation', 'F=': '_data_format',
                             'Q=': '_quality_check', 'I=': '_input_source', 'U=': '_active_passive',
                             'M=': 'motion_reference', 'A=': '_1pps'}
@@ -4207,6 +4208,12 @@ class kmall():
         translated = {}
         translate = translate_install
         for rec in records_flatten:
+
+            # Catch an corner case there the TX serial number contain a semicolon 
+            # and get split above
+            if rec[0].startswith('TX'):
+                rec = [';'.join(rec)]
+
             # subgroups are parsed here, first rec contains the prefix
             # ex: ['ATTI_1:X=0.000', 'Y=0.000', 'Z=0.000', 'R=0.000', 'P=0.000', 'H=0.000', 'D=0.000'...
             if len(rec) > 1:

--- a/KMALL/kmall.py
+++ b/KMALL/kmall.py
@@ -1065,7 +1065,11 @@ class kmall():
         # TODO: Test with water column data, phaseFlag = 1 and phaseFlag = 2 to ensure this continues to function properly.
 
         dg = {}
-        format_to_unpack = "1f4H"
+
+        # The "detectedRangeInSamplesHighResolution" field is present in my dgmVersion==2
+        # and ==3 data, but given it wasn't implemented in the upstream library, wonder if
+        # it wasn't present in dgmVersion==1
+        format_to_unpack = "1f4H1f"
         fields = struct.unpack(format_to_unpack, self.FID.read(struct.Struct(format_to_unpack).size))
 
         dg['beamPointAngReVertical_deg'] = fields[0]
@@ -1077,6 +1081,9 @@ class kmall():
         dg['beamTxSectorNum'] = fields[3]
         # Number of sample data for current beam. Also denoted Ns.
         dg['numSampleData'] = fields[4]
+
+        # Two way range as a higher resolution floating point value
+        dg['detectedRangeInSamplesHighResolution'] = fields[5]
 
         # Pointer to start of array with Water Column data. Length of array = numSampleData.
         # Sample amplitudes in 0.5 dB resolution. Size of array is numSampleData * int8_t.

--- a/KMALL/kmall.py
+++ b/KMALL/kmall.py
@@ -3323,7 +3323,7 @@ class kmall():
 
             dgm_type = dgm_type0 + dgm_type1 + dgm_type2 + dgm_type3
 
-            self.msgtype.append(str(dgm_type))
+            self.msgtype.append(dgm_type.decode())
             # Decode time
             # osec = sec
             # osec *= 1E9

--- a/Readme.md
+++ b/Readme.md
@@ -29,5 +29,46 @@ Although low-level readers for many of the datagram types is in place, little ot
 
 See [the examples](KMALL_examples.rst) for details about using the module.
 
+## Coordinate systems
+
+### Vessel Coordinate System (VCS)
+
+Origo of the VCS is the vessel reference point. The VCS is defined according to the right hand rule.
+
+    x-axis pointing forward parallel to the vessel main axis.
+    y-axis pointing starboard parallel to the deck plane.
+    z-axis pointing down parallel to the mast.
+
+Rotation of the vessel coordinate system around an axis is defined as positive in the clockwise direction, also according to the right hand rule.
+
+    Roll - rotation around the x-axis. (positive when starboard is down)
+    Pitch - rotation around the y-axis. (positive when bow is up)
+    Heading - rotation around the z-axis. Heading as input in depth calculations is sensor data referred to true north. (positive is clockwise when looking down, like traditional heading)
+
+### Array Coordinate System (ACS)
+
+Origo of the ACS is at the centre of the array face. The ACS is defined according to the right hand rule.
+
+    x-axis pointing forward along the array (parallel to the vessel main axis).
+    y-axis pointing starboard along the array plane.
+    z-axis pointing down orthogonal to the array plane.
+
+### Surface Coordinate System (SCS)
+
+Origo of the SCS is the vessel reference point at the time of transmission. The SCS is defined according to the right hand rule.
+
+    x-axis pointing forward along the horizontal projection of the vessel main axis.
+    y-axis pointing horizontally to starboard, orthogonal to the horizontal projection of the vessel main axis.
+    z-axis pointing down along the g-vector.
+
+To move SCS into the waterline, use reference point height corrected for roll and pitch at the time of transmission.
+
+### Fixed Coordinate System (FCS)
+
+Origo of the FCS is fixed somewhere in the nominal sea surface. The FCS is defined according to the right hand rule.
+
+    x-axis pointing north.
+    y-axis pointing east.
+    z-axis pointing down along the g-vector.
 
 > Written with [StackEdit](https://stackedit.io/).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,9 @@
+# Scripts
+
+The scripts directory containts useful scripts that uses the KMALL module.
+
+## kmall_to_ros_bag.py
+
+Converts xyz points from kmall files into ROS PointCloud2 messages and saves them into one or more ROS bag files.
+
+For more information, run: kmall_to_ros_bag.py --help

--- a/scripts/kmall_to_ros_bag.py
+++ b/scripts/kmall_to_ros_bag.py
@@ -1,0 +1,124 @@
+#!/bin/env python3
+
+# Converts xyz points from kmall files into
+# ROS PointCloud2 messages and saves them into one
+# or more ROS bag files.
+
+import KMALL
+import argparse
+import datetime
+import struct
+
+try:
+    import rospy
+    import rosbag
+    from sensor_msgs.msg import PointCloud2, PointField
+    from tf2_msgs.msg import TFMessage
+    from geometry_msgs.msg import TransformStamped
+except ModuleNotFoundError as e:
+    print('\nThis is script is meant to run on a system running the Robotic Operating System (ROS).\n')
+    raise
+    
+
+
+parser = argparse.ArgumentParser(description="Convert soundings from kmall files to ROS Pointcloud2 messages and saves to ROS bag files.")
+
+parser.add_argument("inputs", metavar="input.kmall", nargs='+', help="Input kmall file.")
+
+parser.add_argument("-o", "--output", help="Output bag file. If omitted, a bag file for each input file will be created by adding '.bag' to each input filename. When an output bag file is spcified, the data from all input files will be saved to that single bag file.")
+
+parser.add_argument("-t", "--topic", default="mbes/pings", help="Topic where PointCloud2 messages will appear. (default: %(default)s)")
+
+parser.add_argument("-f", "--frame_id", default="mbes", help="The Frame ID used in the PointCloud2 messages. (default: %(default)s)")
+
+tf_parser = parser.add_argument_group("Transform messages", "Optional transform messages from a parent frame to frame_id can be saved to the bag file(s). The default orientation flips the sensor upside down to match the typical mounting on a surface survey ship.")
+
+tf_parser.add_argument("-tf", "--tf", help="Enable saving of transform messages in topic /tf. (default: %(default)s)", action="store_true")
+
+tf_parser.add_argument("-p", "--parent_frame_id", default="base_link_level", help="Parent frame for transform messages. (default: %(default)s)")
+
+tf_parser.add_argument("-tx", "--translate_x", type=float, default=0.0, help="X translate component (default: %(default)s)")
+
+tf_parser.add_argument("-ty", "--translate_y", type=float, default=0.0, help="Y translate component (default: %(default)s)")
+
+tf_parser.add_argument("-tz", "--translate_z", type=float, default=0.0, help="Z translate component (default: %(default)s)")
+
+tf_parser.add_argument("-qx", "--quaternion_x", type=float, default=1.0, help="X quaternion rotation component (default: %(default)s)")
+
+tf_parser.add_argument("-qy", "--quaternion_y", type=float, default=0.0, help="Y quaternion rotation component (default: %(default)s)")
+
+tf_parser.add_argument("-qz", "--quaternion_z", type=float, default=0.0, help="Z quaternion rotation component (default: %(default)s)")
+
+tf_parser.add_argument("-qw", "--quaternion_w", type=float, default=0.0, help="W quaternion rotation component (default: %(default)s)")
+
+args = parser.parse_args()
+
+# A single bag file is created if output filename is provided.
+if args.output is not None:
+    bag = rosbag.Bag(args.output, 'w')
+
+if args.tf:
+    transform = TransformStamped()
+    transform.header.frame_id = args.parent_frame_id
+    transform.child_frame_id = args.frame_id
+    transform.transform.translation.x = args.translate_x
+    transform.transform.translation.y = args.translate_y
+    transform.transform.translation.z = args.translate_z
+    transform.transform.rotation.x = args.quaternion_x
+    transform.transform.rotation.y = args.quaternion_y
+    transform.transform.rotation.z = args.quaternion_z
+    transform.transform.rotation.w = args.quaternion_w
+
+for kfile in args.inputs:
+    # Create a bag file per input file if output is ommited
+    if args.output is None:
+        bag = rosbag.Bag(kfile+'.bag', 'w')
+
+    k = KMALL.kmall(kfile)
+    while not k.eof:
+        k.decode_datagram()
+        if k.datagram_ident == 'MRZ':
+            k.read_datagram()
+            mrz = k.datagram_data
+            
+            pc = PointCloud2()
+            pc.header.frame_id = args.frame_id
+            pc.header.stamp = rospy.Time.from_sec(mrz['header']['dgdatetime'].replace(tzinfo=datetime.timezone.utc).timestamp())
+
+            pc.fields.append(PointField(name="x", offset=0, datatype=PointField.FLOAT32, count=1))
+            pc.fields.append(PointField(name="y", offset=4, datatype=PointField.FLOAT32, count=1))
+            pc.fields.append(PointField(name="z", offset=8, datatype=PointField.FLOAT32, count=1))
+            pc.fields.append(PointField(name="backscatter", offset=12, datatype=PointField.FLOAT32, count=1))
+
+            pc.height = 1
+            pc.width = len(mrz['sounding']['x_reRefPoint_m'])
+
+            pc.is_bigendian = False
+            pc.point_step = 16 # four x four byte floats
+            pc.row_step = pc.width*pc.point_step
+            pc.is_dense = True
+
+            for i in range(pc.width):
+                pc.data += struct.pack('<ffff', mrz['sounding']['x_reRefPoint_m'][i], 
+                                       mrz['sounding']['y_reRefPoint_m'][i],
+                                       mrz['sounding']['z_reRefPoint_m'][i],
+                                       mrz['sounding']['reflectivity1_dB'][i])
+
+            if args.tf:
+                transform.header.stamp = pc.header.stamp
+                tfm = TFMessage()
+                tfm.transforms.append(transform)
+                bag.write('/tf', tfm, transform.header.stamp)
+
+            bag.write(args.topic, pc, pc.header.stamp)
+        else:
+            k.skip_datagram()
+
+    # only close bag file if using per input bags
+    if args.output is None:
+        bag.close()
+
+# Only close if using a single bag for output.
+# per input bags should be closed already by now.
+if args.output is not None:
+    bag.close()


### PR DESCRIPTION
Changes from our testing with the EM2040 in UNH test tank April 2024.   Primarily:

- Fix bug in reading the MWC rx data struct in newer version of datagrams.
- Decode packet names to string (rather than byte arrays) for convenience
- More ubiquitous use of empty string rather than None --- Scipy's .mat write chokes on None